### PR TITLE
Feature/add licence

### DIFF
--- a/LICENCE.md
+++ b/LICENCE.md
@@ -1,0 +1,306 @@
+# Licence
+
+Copyright © VNG Realisatie 2017  
+Licensed under the EUPL
+
+**Table of Contents**
+
+* [EUPL text in English](#eupl-text-in-english)
+* [EUPL text in Dutch (governing law)](#eupl-text-in-dutch)
+
+## EUPL text in English
+
+```
+EUROPEAN UNION PUBLIC LICENCE v. 1.2 
+EUPL © the European Union 2007, 2016 
+
+This European Union Public Licence (the ‘EUPL’) applies to the Work (as defined below) which is provided under the 
+terms of this Licence. Any use of the Work, other than as authorised under this Licence is prohibited (to the extent such 
+use is covered by a right of the copyright holder of the Work). 
+The Work is provided under the terms of this Licence when the Licensor (as defined below) has placed the following 
+notice immediately following the copyright notice for the Work: 
+                          Licensed under the EUPL 
+or has expressed by any other means his willingness to license under the EUPL. 
+
+1.Definitions 
+In this Licence, the following terms have the following meaning: 
+— ‘The Licence’:this Licence. 
+— ‘The Original Work’:the work or software distributed or communicated by the Licensor under this Licence, available 
+as Source Code and also as Executable Code as the case may be. 
+— ‘Derivative Works’:the works or software that could be created by the Licensee, based upon the Original Work or 
+modifications thereof. This Licence does not define the extent of modification or dependence on the Original Work 
+required in order to classify a work as a Derivative Work; this extent is determined by copyright law applicable in 
+the country mentioned in Article 15. 
+— ‘The Work’:the Original Work or its Derivative Works. 
+— ‘The Source Code’:the human-readable form of the Work which is the most convenient for people to study and 
+modify. 
+— ‘The Executable Code’:any code which has generally been compiled and which is meant to be interpreted by 
+a computer as a program. 
+— ‘The Licensor’:the natural or legal person that distributes or communicates the Work under the Licence. 
+— ‘Contributor(s)’:any natural or legal person who modifies the Work under the Licence, or otherwise contributes to 
+the creation of a Derivative Work. 
+— ‘The Licensee’ or ‘You’:any natural or legal person who makes any usage of the Work under the terms of the 
+Licence. 
+— ‘Distribution’ or ‘Communication’:any act of selling, giving, lending, renting, distributing, communicating, 
+transmitting, or otherwise making available, online or offline, copies of the Work or providing access to its essential 
+functionalities at the disposal of any other natural or legal person. 
+
+2.Scope of the rights granted by the Licence 
+The Licensor hereby grants You a worldwide, royalty-free, non-exclusive, sublicensable licence to do the following, for 
+the duration of copyright vested in the Original Work: 
+— use the Work in any circumstance and for all usage, 
+— reproduce the Work, 
+— modify the Work, and make Derivative Works based upon the Work, 
+— communicate to the public, including the right to make available or display the Work or copies thereof to the public 
+and perform publicly, as the case may be, the Work, 
+— distribute the Work or copies thereof, 
+— lend and rent the Work or copies thereof, 
+— sublicense rights in the Work or copies thereof. 
+Those rights can be exercised on any media, supports and formats, whether now known or later invented, as far as the 
+applicable law permits so. 
+In the countries where moral rights apply, the Licensor waives his right to exercise his moral right to the extent allowed 
+by law in order to make effective the licence of the economic rights here above listed. 
+The Licensor grants to the Licensee royalty-free, non-exclusive usage rights to any patents held by the Licensor, to the 
+extent necessary to make use of the rights granted on the Work under this Licence. 
+
+3.Communication of the Source Code 
+The Licensor may provide the Work either in its Source Code form, or as Executable Code. If the Work is provided as 
+Executable Code, the Licensor provides in addition a machine-readable copy of the Source Code of the Work along with 
+each copy of the Work that the Licensor distributes or indicates, in a notice following the copyright notice attached to 
+the Work, a repository where the Source Code is easily and freely accessible for as long as the Licensor continues to 
+distribute or communicate the Work. 
+
+4.Limitations on copyright 
+Nothing in this Licence is intended to deprive the Licensee of the benefits from any exception or limitation to the 
+exclusive rights of the rights owners in the Work, of the exhaustion of those rights or of other applicable limitations 
+thereto. 
+
+5.Obligations of the Licensee 
+The grant of the rights mentioned above is subject to some restrictions and obligations imposed on the Licensee. Those 
+obligations are the following: 
+
+Attribution right: The Licensee shall keep intact all copyright, patent or trademarks notices and all notices that refer to 
+the Licence and to the disclaimer of warranties. The Licensee must include a copy of such notices and a copy of the 
+Licence with every copy of the Work he/she distributes or communicates. The Licensee must cause any Derivative Work 
+to carry prominent notices stating that the Work has been modified and the date of modification. 
+
+Copyleft clause: If the Licensee distributes or communicates copies of the Original Works or Derivative Works, this 
+Distribution or Communication will be done under the terms of this Licence or of a later version of this Licence unless 
+the Original Work is expressly distributed only under this version of the Licence — for example by communicating 
+‘EUPL v. 1.2 only’. The Licensee (becoming Licensor) cannot offer or impose any additional terms or conditions on the 
+Work or Derivative Work that alter or restrict the terms of the Licence. 
+
+Compatibility clause: If the Licensee Distributes or Communicates Derivative Works or copies thereof based upon both 
+the Work and another work licensed under a Compatible Licence, this Distribution or Communication can be done 
+under the terms of this Compatible Licence. For the sake of this clause, ‘Compatible Licence’ refers to the licences listed 
+in the appendix attached to this Licence. Should the Licensee's obligations under the Compatible Licence conflict with 
+his/her obligations under this Licence, the obligations of the Compatible Licence shall prevail. 
+
+Provision of Source Code: When distributing or communicating copies of the Work, the Licensee will provide 
+a machine-readable copy of the Source Code or indicate a repository where this Source will be easily and freely available 
+for as long as the Licensee continues to distribute or communicate the Work. 
+Legal Protection: This Licence does not grant permission to use the trade names, trademarks, service marks, or names 
+of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and 
+reproducing the content of the copyright notice. 
+
+6.Chain of Authorship 
+The original Licensor warrants that the copyright in the Original Work granted hereunder is owned by him/her or 
+licensed to him/her and that he/she has the power and authority to grant the Licence. 
+Each Contributor warrants that the copyright in the modifications he/she brings to the Work are owned by him/her or 
+licensed to him/her and that he/she has the power and authority to grant the Licence. 
+Each time You accept the Licence, the original Licensor and subsequent Contributors grant You a licence to their contributions 
+to the Work, under the terms of this Licence. 
+
+7.Disclaimer of Warranty 
+The Work is a work in progress, which is continuously improved by numerous Contributors. It is not a finished work 
+and may therefore contain defects or ‘bugs’ inherent to this type of development. 
+For the above reason, the Work is provided under the Licence on an ‘as is’ basis and without warranties of any kind 
+concerning the Work, including without limitation merchantability, fitness for a particular purpose, absence of defects or 
+errors, accuracy, non-infringement of intellectual property rights other than copyright as stated in Article 6 of this 
+Licence. 
+This disclaimer of warranty is an essential part of the Licence and a condition for the grant of any rights to the Work. 
+
+8.Disclaimer of Liability 
+Except in the cases of wilful misconduct or damages directly caused to natural persons, the Licensor will in no event be 
+liable for any direct or indirect, material or moral, damages of any kind, arising out of the Licence or of the use of the 
+Work, including without limitation, damages for loss of goodwill, work stoppage, computer failure or malfunction, loss 
+of data or any commercial damage, even if the Licensor has been advised of the possibility of such damage. However, 
+the Licensor will be liable under statutory product liability laws as far such laws apply to the Work. 
+
+9.Additional agreements 
+While distributing the Work, You may choose to conclude an additional agreement, defining obligations or services 
+consistent with this Licence. However, if accepting obligations, You may act only on your own behalf and on your sole 
+responsibility, not on behalf of the original Licensor or any other Contributor, and only if You agree to indemnify, 
+defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against such Contributor by 
+the fact You have accepted any warranty or additional liability. 
+
+10.Acceptance of the Licence 
+The provisions of this Licence can be accepted by clicking on an icon ‘I agree’ placed under the bottom of a window 
+displaying the text of this Licence or by affirming consent in any other similar way, in accordance with the rules of 
+applicable law. Clicking on that icon indicates your clear and irrevocable acceptance of this Licence and all of its terms 
+and conditions. 
+Similarly, you irrevocably accept this Licence and all of its terms and conditions by exercising any rights granted to You 
+by Article 2 of this Licence, such as the use of the Work, the creation by You of a Derivative Work or the Distribution 
+or Communication by You of the Work or copies thereof. 
+
+11.Information to the public 
+In case of any Distribution or Communication of the Work by means of electronic communication by You (for example, 
+by offering to download the Work from a remote location) the distribution channel or media (for example, a website) 
+must at least provide to the public the information requested by the applicable law regarding the Licensor, the Licence 
+and the way it may be accessible, concluded, stored and reproduced by the Licensee. 
+
+12.Termination of the Licence 
+The Licence and the rights granted hereunder will terminate automatically upon any breach by the Licensee of the terms 
+of the Licence. 
+Such a termination will not terminate the licences of any person who has received the Work from the Licensee under 
+the Licence, provided such persons remain in full compliance with the Licence. 
+
+13.Miscellaneous 
+Without prejudice of Article 9 above, the Licence represents the complete agreement between the Parties as to the 
+Work. 
+If any provision of the Licence is invalid or unenforceable under applicable law, this will not affect the validity or 
+enforceability of the Licence as a whole. Such provision will be construed or reformed so as necessary to make it valid 
+and enforceable. 
+The European Commission may publish other linguistic versions or new versions of this Licence or updated versions of 
+the Appendix, so far this is required and reasonable, without reducing the scope of the rights granted by the Licence. 
+New versions of the Licence will be published with a unique version number. 
+All linguistic versions of this Licence, approved by the European Commission, have identical value. Parties can take 
+advantage of the linguistic version of their choice. 
+
+14.Jurisdiction 
+Without prejudice to specific agreement between parties, 
+— any litigation resulting from the interpretation of this License, arising between the European Union institutions, 
+bodies, offices or agencies, as a Licensor, and any Licensee, will be subject to the jurisdiction of the Court of Justice 
+of the European Union, as laid down in article 272 of the Treaty on the Functioning of the European Union, 
+— any litigation arising between other parties and resulting from the interpretation of this License, will be subject to 
+the exclusive jurisdiction of the competent court where the Licensor resides or conducts its primary business. 
+
+15.Applicable Law 
+Without prejudice to specific agreement between parties, 
+— this Licence shall be governed by the law of the European Union Member State where the Licensor has his seat, 
+resides or has his registered office, 
+— this licence shall be governed by Belgian law if the Licensor has no seat, residence or registered office inside 
+a European Union Member State. 
+
+
+                                                         Appendix 
+
+‘Compatible Licences’ according to Article 5 EUPL are: 
+— GNU General Public License (GPL) v. 2, v. 3 
+— GNU Affero General Public License (AGPL) v. 3 
+— Open Software License (OSL) v. 2.1, v. 3.0 
+— Eclipse Public License (EPL) v. 1.0 
+— CeCILL v. 2.0, v. 2.1 
+— Mozilla Public Licence (MPL) v. 2 
+— GNU Lesser General Public Licence (LGPL) v. 2.1, v. 3 
+— Creative Commons Attribution-ShareAlike v. 3.0 Unported (CC BY-SA 3.0) for works other than software 
+— European Union Public Licence (EUPL) v. 1.1, v. 1.2 
+— Québec Free and Open-Source Licence — Reciprocity (LiLiQ-R) or Strong Reciprocity (LiLiQ-R+).
+
+The European Commission may update this Appendix to later versions of the above licences without producing 
+a new version of the EUPL, as long as they provide the rights granted in Article 2 of this Licence and protect the 
+covered Source Code from exclusive appropriation. 
+All other changes or additions to this Appendix require the production of a new EUPL version. 
+```
+
+## EUPL text in Dutch
+
+```
+OPENBARE LICENTIE VAN DE EUROPESE UNIE v. 1.2. 
+EUPL © Europese Unie 2007, 2016 
+Deze openbare licentie van de Europese Unie („EUPL”) is van toepassing op het werk (zoals hieronder gedefinieerd) dat onder de voorwaarden van deze licentie wordt verstrekt. Elk gebruik van het werk dat niet door deze licentie is toegestaan, is verboden (voor zover dit gebruik valt onder een recht van de houder van het auteursrecht op het werk). Het werk wordt verstrekt onder de voorwaarden van deze licentie wanneer de licentiegever (zoals hieronder gedefinieerd), direct volgend op de kennisgeving inzake het auteursrecht op het werk, de volgende kennisgeving opneemt: 
+                  In licentie gegeven krachtens de EUPL 
+of op een andere wijze zijn bereidheid te kennen heeft gegeven krachtens de EUPL in licentie te geven. 
+
+1.Definities 
+In deze licentie wordt verstaan onder:  
+— „de licentie”:de onderhavige licentie;  
+— „het oorspronkelijke werk”:het werk dat of de software die door de licentiegever krachtens deze licentie wordt verspreid of medegedeeld, en dat/die beschikbaar is als broncode en, in voorkomend geval, ook als uitvoerbare code;  
+— „bewerkingen”:de werken of software die de licentiehouder kan creëren op grond van het oorspronkelijke werk of wijzigingen ervan. In deze licentie wordt niet gedefinieerd welke mate van wijziging of afhankelijkheid van het oorspronkelijke werk vereist is om een werk als een bewerking te kunnen aanmerken; dat wordt bepaald conform het auteursrecht dat van toepassing is in de in artikel 15 bedoelde staat;  
+— „het werk”:het oorspronkelijke werk of de bewerkingen ervan;  
+— „de broncode”:de voor mensen leesbare vorm van het werk, die het gemakkelijkste door mensen kan worden bestudeerd en gewijzigd;  
+— „de uitvoerbare code”:elke code die over het algemeen is gecompileerd en is bedoeld om door een computer als een programma te worden uitgevoerd;  
+— „de licentiegever”:de natuurlijke of rechtspersoon die het werk krachtens de licentie verspreidt of mededeelt;  
+— „bewerker(s)”:elke natuurlijke of rechtspersoon die het werk krachtens de licentie wijzigt of op een andere wijze bijdraagt tot de totstandkoming van een bewerking;  
+— „de licentiehouder” of „u”:elke natuurlijke of rechtspersoon die het werk onder de voorwaarden van de licentie gebruikt;  — „verspreiding” of „mededeling”:het verkopen, geven, uitlenen, verhuren, verspreiden, mededelen, doorgeven, of op een andere wijze online of offline beschikbaar stellen van kopieën van het werk of het verlenen van toegang tot de essentiële functies ervan ten behoeve van andere natuurlijke of rechtspersonen. 
+
+2.Draagwijdte van de uit hoofde van de licentie verleende rechten 
+De licentiegever verleent u hierbij een wereldwijde, royaltyvrije, niet-exclusieve, voor een sublicentie in aanmerking komende licentie, om voor de duur van het aan het oorspronkelijke werk verbonden auteursrecht, het volgende te doen: 
+—  het werk in alle omstandigheden en voor ongeacht welk doel te gebruiken; 
+—  het werk te verveelvoudigen; 
+—  het werk te wijzigen en op grond van het werk bewerkingen te ontwikkelen; 
+—  het werk aan het publiek mede te delen, waaronder het recht om het werk of kopieën ervan aan het publiek ter beschikking te stellen of te vertonen, en het werk, in voorkomend geval, in het openbaar uit te voeren;
+—  het werk of kopieën ervan te verspreiden; 
+—  het werk of kopieën ervan uit te lenen en te verhuren; 
+—  de rechten op het werk of op kopieën ervan in sublicentie te geven. 
+Deze rechten kunnen worden uitgeoefend met gebruikmaking van alle thans bekende of nog uit te vinden media, dragers en formaten, voor zover het toepasselijke recht dit toestaat. In de landen waar immateriële rechten van toepassing zijn, doet de licentiegever afstand van zijn recht op uitoefening van zijn immateriële rechten in de mate die door het toepasselijke recht wordt toegestaan teneinde een doeltreffende uitoefening van de bovenvermelde in licentie gegeven economische rechten mogelijk te maken. De licentiegever verleent de licentiehouder een royaltyvrij, niet-exclusief gebruiksrecht op alle octrooien van de licentiegever, voor zover dit noodzakelijk is om de uit hoofde van deze licentie verleende rechten op het werk te gebruiken. 
+
+3.Mededeling van de broncode 
+De licentiegever kan het werk verstrekken in zijn broncode of als uitvoerbare code. Indien het werk als uitvoerbare code wordt verstrekt, verstrekt de licentiegever bij elke door hem verspreide kopie van het werk tevens een machinaal leesbare kopie van de broncode van het werk of geeft hij in een mededeling, volgende op de bij het werk gevoegde auteursrechtelijke kennisgeving, de plaats aan waar de broncode gemakkelijk en vrij toegankelijk is, zolang de licentiegever het werk blijft verspreiden of mededelen. 
+
+4.Beperkingen van het auteursrecht 
+Geen enkele bepaling in deze licentie heeft ten doel de licentiehouder het recht te ontnemen een beroep te doen op een uitzondering op of een beperking van de exclusieve rechten van de rechthebbenden op het werk, of op de uitputting van die rechten of andere toepasselijke beperkingen daarvan. 
+
+5.Verplichtingen van de licentiehouder 
+De verlening van de bovenvermelde rechten is onderworpen aan een aantal aan de licentiehouder opgelegde beperkingen en verplichtingen. Het gaat om de onderstaande verplichtingen.
+
+Attributierecht: de licentiehouder moet alle auteurs-, octrooi- of merkenrechtelijke kennisgevingen onverlet laten alsook alle kennisgevingen die naar de licentie en de afwijzing van garanties verwijzen. De licentiehouder moet een afschrift van deze kennisgevingen en een afschrift van de licentie bij elke kopie van het werk voegen die hij verspreidt of mededeelt. De licentiehouder moet in elke bewerking duidelijk aangeven dat het werk is gewijzigd, en eveneens de datum van wijziging vermelden. 
+
+Copyleftclausule: wanneer de licentiehouder kopieën van het oorspronkelijke werk of bewerkingen verspreidt of mededeelt, geschiedt die verspreiding of mededeling onder de voorwaarden van deze licentie of van een latere versie van deze licentie, tenzij het oorspronkelijke werk uitdrukkelijk alleen onder deze versie van de licentie wordt verspreid — bijvoorbeeld door de mededeling „alleen EUPL v. 1.2”. De licentiehouder (die licentiegever wordt) kan met betrekking tot het werk of de bewerkingen geen aanvullende bepalingen of voorwaarden opleggen of stellen die de voorwaarden van de licentie wijzigen of beperken. 
+
+Verenigbaarheidsclausule: wanneer de licentiehouder bewerkingen of kopieën ervan verspreidt of mededeelt die zijn gebaseerd op het werk en op een ander werk dat uit hoofde van een verenigbare licentie in licentie is gegeven, kan die verspreiding of mededeling geschieden onder de voorwaarden van deze verenigbare licentie. Voor de toepassing van deze clausule wordt onder „verenigbare licentie” verstaan, de licenties die in het aanhangsel bij deze licentie zijn opgesomd. Indien de verplichtingen van de licentiehouder uit hoofde van de verenigbare licentie in strijd zijn met diens verplichtingen uit hoofde van deze licentie, hebben de verplichtingen van de verenigbare licentie voorrang. 
+
+Verstrekking van de broncode: bij de verspreiding of mededeling van kopieën van het werk verstrekt de licentiehouder een machinaal leesbare kopie van de broncode of geeft hij aan waar deze broncode gemakkelijk en vrij toegankelijk is, zolang de licentiehouder het werk blijft verspreiden of mededelen. 
+
+Juridische bescherming: deze licentie verleent geen toestemming om handelsnamen, handelsmerken, dienstmerken of namen van de licentiegever te gebruiken, behalve wanneer dit op grond van een redelijk en normaal gebruik noodzakelijk is om de oorsprong van het werk te beschrijven en de inhoud van de auteursrechtelijke kennisgeving te herhalen.
+
+6.Auteursketen 
+De oorspronkelijke licentiegever garandeert dat hij houder is van het hierbij verleende auteursrecht op het oorspronkelijke werk dan wel dat dit hem in licentie is gegeven en dat hij de bevoegdheid heeft de licentie te verlenen. Elke bewerker garandeert dat hij houder is van het auteursrecht op de door hem aan het werk aangebrachte wijzigingen dan wel dat dit hem in licentie is gegeven en dat hij de bevoegdheid heeft de licentie te verlenen. Telkens wanneer u de licentie aanvaardt, verlenen de oorspronkelijke licentiegever en de opeenvolgende bewerkers u een licentie op hun bijdragen aan het werk onder de voorwaarden van deze licentie. 
+
+7.Uitsluiting van garantie 
+Het werk is een werk in ontwikkeling, dat voortdurend door vele bewerkers wordt verbeterd. Het is een onvoltooid werk, dat bijgevolg nog tekortkomingen of programmeerfouten („bugs”) kan vertonen, die onlosmakelijk verbonden zijn met dit soort ontwikkeling. Om die reden wordt het werk op grond van de licentie verstrekt „zoals het is” en zonder enige garantie met betrekking tot het werk te geven, met inbegrip van, maar niet beperkt tot garanties met betrekking tot de verhandelbaarheid, de geschiktheid voor een specifiek doel, de afwezigheid van tekortkomingen of fouten, de nauwkeurigheid, de eerbiediging van andere intellectuele-eigendomsrechten dan het in artikel 6 van deze licentie bedoelde auteursrecht. Deze uitsluiting van garantie is een essentieel onderdeel van de licentie en een voorwaarde voor de verlening van rechten op het werk. 
+
+8.Uitsluiting van aansprakelijkheid 
+Behoudens in het geval van een opzettelijke fout of directe schade aan natuurlijke personen, is de licentiegever in geen enkel geval aansprakelijk voor ongeacht welke directe of indirecte, materiële of immateriële schade die voortvloeit uit de licentie of het gebruik van het werk, met inbegrip van, maar niet beperkt tot schade als gevolg van het verlies van goodwill, verloren werkuren, een computerdefect of computerfout, het verlies van gegevens, of enige andere commerciële schade, zelfs indien de licentiegever werd gewezen op de mogelijkheid van dergelijke schade. De licentiegever is echter aansprakelijk op grond van de wetgeving inzake productaansprakelijkheid, voor zover deze wetgeving op het werk van toepassing is. 
+
+9.Aanvullende overeenkomsten 
+Bij de verspreiding van het werk kunt u ervoor kiezen een aanvullende overeenkomst te sluiten, waarin de verplichtingen of diensten overeenkomstig deze licentie worden omschreven. Indien deze verplichtingen worden aanvaard, kunt u echter alleen in eigen naam en onder eigen verantwoordelijkheid handelen, en dus niet in naam van de oorspronkelijke licentiegever of een bewerker, en kunt u voorts alleen handelen indien u ermee instemt alle bewerkers schadeloos te stellen, te verdedigen of te vrijwaren met betrekking tot de aansprakelijkheid van of vorderingen tegen deze bewerkers op grond van het feit dat u een garantie of aanvullende aansprakelijkheid hebt aanvaard. 
+
+10.Aanvaarding van de licentie 
+De bepalingen van deze licentie kunnen worden aanvaard door te klikken op het pictogram „Ik ga akkoord”, dat zich bevindt onderaan het venster waarin de tekst van deze licentie is weergegeven, of door overeenkomstig de toepasselijke wetsbepalingen op een soortgelijke wijze met de licentie in te stemmen. Door op dat pictogram te klikken geeft u aan dat u deze licentie en alle voorwaarden ervan ondubbelzinnig en onherroepelijk aanvaardt. Evenzo aanvaardt u onherroepelijk deze licentie en alle voorwaarden ervan door uitoefening van de rechten die u in artikel 2 van deze licentie zijn verleend, zoals het gebruik van het werk, het creëren door u van een bewerking of de verspreiding of mededeling door u van het werk of kopieën ervan. 
+
+11.Voorlichting van het publiek 
+Indien u het werk verspreidt of mededeelt door middel van elektronische communicatiemiddelen (bijvoorbeeld door voor te stellen het werk op afstand te downloaden), moet het distributiekanaal of het medium (bijvoorbeeld een website) het publiek ten minste de gegevens verschaffen die door het toepasselijke recht zijn voorgeschreven met betrekking tot de licentiegever, de licentie en de wijze waarop deze kan worden geraadpleegd, gesloten, opgeslagen en gereproduceerd door de licentiehouder.
+
+12.Einde van de licentie 
+De licentie en de uit hoofde daarvan verleende rechten eindigen automatisch bij elke inbreuk door de licentiehouder op de voorwaarden van de licentie. Dit einde beëindigt niet de licenties van personen die het werk van de licentiehouder krachtens de licentie hebben ontvangen, mits deze personen zich volledig aan de licentie houden. 
+
+13.Overige 
+Onverminderd artikel 9 vormt de licentie de gehele overeenkomst tussen de partijen met betrekking tot het werk. Indien een bepaling van de licentie volgens het toepasselijke recht ongeldig is of niet uitvoerbaar is, doet dit geen afbreuk aan de geldigheid of uitvoerbaarheid van de licentie in haar geheel. Deze bepaling dient zodanig te worden uitgelegd of gewijzigd dat zij geldig en uitvoerbaar wordt. De Europese Commissie kan, voor zover dit noodzakelijk en redelijk is, versies in andere talen of nieuwe versies van deze licentie of geactualiseerde versies van dit aanhangsel publiceren, zonder de draagwijdte van de uit hoofde van de licentie verleende rechten te beperken. Nieuwe versies van de licentie zullen worden gepubliceerd met een uniek versienummer. Alle door de Europese Commissie goedgekeurde taalversies van deze licentie hebben dezelfde waarde. De partijen kunnen zich beroepen op de taalversie van hun keuze. 
+
+14.Bevoegd gerecht
+Onverminderd specifieke overeenkomsten tussen de partijen, 
+—  vallen alle geschillen tussen de instellingen, organen en instanties van de Europese Unie, als licentiegeefster, en een licentiehouder in verband met de uitlegging van deze licentie onder de bevoegdheid van het Hof van Justitie van de Europese Unie, conform artikel 272 van het Verdrag betreffende de werking van de Europese Unie, 
+—  vallen alle geschillen tussen andere partijen in verband met de uitlegging van deze licentie onder de uitsluitende bevoegdheid van het bevoegde gerecht van de plaats waar de licentiegever is gevestigd of zijn voornaamste activiteit uitoefent. 
+
+15.Toepasselijk recht 
+Onverminderd specifieke overeenkomsten tussen de partijen, 
+—  wordt deze licentie beheerst door het recht van de lidstaat van de Europese Unie waar de licentiegever zijn statutaire zetel, verblijfplaats of hoofdkantoor heeft, 
+—  wordt deze licentie beheerst door het Belgische recht indien de licentiegever geen statutaire zetel, verblijfplaats of hoofdkantoor heeft in een lidstaat van de Europese Unie.
+
+   
+Aanhangsel 
+„Verenigbare licenties” in de zin van artikel 5 EUPL zijn: 
+—  GNU General Public License (GPL) v. 2, v. 3 
+—  GNU Affero General Public License (AGPL) v. 3 
+—  Open Software License (OSL) v. 2.1, v. 3.0 
+—  Eclipse Public License (EPL) v. 1.0 
+—  CeCILL v. 2.0, v. 2.1 
+—  Mozilla Public Licence (MPL) v. 2 
+—  GNU Lesser General Public Licence (LGPL) v. 2.1, v. 3 
+—  Creative Commons Attribution-ShareAlike v. 3.0 Unported (CC BY-SA 3.0) voor andere werken dan software 
+—  European Union Public Licence (EUPL) v. 1.1, v. 1.2 
+—  Québec Free and Open-Source Licence — Reciprocity (LiLiQ-R) of Strong Reciprocity (LiLiQ-R+).
+De Europese Commissie kan dit aanhangsel actualiseren in geval van latere versies van de bovengenoemde licenties zonder dat er een nieuwe EUPL-versie wordt ontwikkeld, zolang die versies de uit hoofde van artikel 2 van deze licentie verleende rechten verlenen en ze de betrokken broncode beschermen tegen exclusieve toe-eigening.
+Voor alle andere wijzigingen van of aanvullingen op dit aanhangsel is de ontwikkeling van een nieuwe EUPL-versie vereist.
+```

--- a/README.md
+++ b/README.md
@@ -3,3 +3,8 @@ NLX
 [![Build Status](https://jenkins.nlx.io/job/nlx/badge/icon?style=plastic)](https://jenkins.nlx.io/job/nlx/)
 
 **NLX** is an open source inter-organisational system facilitating federated authentication, secure connecting and protocolling in a large-scale, dynamic API landscape.
+
+## Licence
+
+Copyright © VNG Realisatie 2017  
+[Licensed under the EUPL](LICENCE.md)


### PR DESCRIPTION
Added an [English](https://joinup.ec.europa.eu/sites/default/files/inline-files/EUPL%20v1_2%20EN(1).txt) and [Dutch](https://joinup.ec.europa.eu/sites/default/files/inline-files/EUPL%20v1_2%20NL.txt) version (since Dutch is the governing law). Text copied directly from the EC site.

I've embedded it as 'code' in the Markdown file as to not destroy the original formatting.

Closes #19 