### PR TITLE
Add TLS between inway and outway

### DIFF
--- a/common/orgtls/load.go
+++ b/common/orgtls/load.go
@@ -1,4 +1,4 @@
-package nlxtls
+package orgtls
 
 import (
 	"crypto/x509"
@@ -15,7 +15,7 @@ func Load(options TLSOptions) (*x509.CertPool, *x509.Certificate, error) {
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "failed to read NLX CA root PEM file `%s`", options.NLXRootCert)
 	}
-	ok := roots.AppendCertsFromPEM([]byte(rootPEM))
+	ok := roots.AppendCertsFromPEM(rootPEM)
 	if !ok {
 		return nil, nil, errors.Errorf("failed to parse NLX CA root PEM from file `%s`", options.NLXRootCert)
 	}
@@ -24,7 +24,7 @@ func Load(options TLSOptions) (*x509.CertPool, *x509.Certificate, error) {
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "failed to read certificate PEM file `%s`", options.OrgCertFile)
 	}
-	block, _ := pem.Decode([]byte(certPEM))
+	block, _ := pem.Decode(certPEM)
 	if block == nil {
 		return nil, nil, errors.New("failed to parse certificate PEM")
 	}

--- a/common/orgtls/options.go
+++ b/common/orgtls/options.go
@@ -1,4 +1,4 @@
-package nlxtls
+package orgtls
 
 // TLSOptions defines the TLS options for a common NLX component.
 type TLSOptions struct {

--- a/common/process/setup.go
+++ b/common/process/setup.go
@@ -1,0 +1,22 @@
+package process
+
+import (
+	"runtime"
+
+	"go.uber.org/zap"
+)
+
+var logger *zap.Logger
+
+// Setup performs common process setup for nlx daemons
+func Setup(l *zap.Logger) {
+	logger = l
+	logger.Debug("setting up process")
+
+	// Currently we develop for linux, binaries might be compiled for other platforms but we should warn the user about possible unexpected behaviour
+	if runtime.GOOS != "linux" {
+		logger.Warn("detected non-linux OS, program might behave unexpected", zap.String("os", runtime.GOOS))
+	}
+
+	setupSignals()
+}

--- a/common/process/signal.go
+++ b/common/process/signal.go
@@ -1,0 +1,31 @@
+package process
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+
+	"go.uber.org/zap"
+)
+
+func setupSignals() {
+	// Catch signals
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT)
+	signal.Notify(sigChan, syscall.SIGQUIT)
+	signal.Notify(sigChan, syscall.SIGTERM)
+	go func() {
+		for sig := range sigChan {
+			logger = logger.With(zap.String("sig", sig.String()))
+			logger.Debug("received a signal")
+			switch syssig := sig.(syscall.Signal); syssig {
+			case syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTERM:
+				logger.Info("shutting down because of signal")
+				// TODO(GeertJohan): run through Exit() function which runs shutdown/cleanup functions (ExitFunc's) and tries to perform graceful shutdown
+				os.Exit(128 + int(syssig))
+			default:
+				logger.Info("ignoring signal")
+			}
+		}
+	}()
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,16 @@
 version: '3.5'
 
 volumes:
-  inway_cert: {}
-  outway_cert: {}
+  inway_cert:
+    driver: local
+    driver_opts:
+      type: tmpfs
+      device: tmpfs
+  outway_cert:
+    driver: local
+    driver_opts:
+      type: tmpfs
+      device: tmpfs
 
 services:
   docs:
@@ -33,7 +41,12 @@ services:
       - ca
     volumes:
       - inway_cert:/inway_cert
-    command: /bin/ash -c "cd /inway_cert && /ca/generate-cert.sh inway.nlx.local ca"
+    command: >
+      /bin/ash -c "
+        cd /inway_cert &&
+        /ca/generate-cert.sh inway.nlx.local DemoProviderOrganization ca &&
+        touch /inway_cert/.done
+      "
 
   inway:
     build:
@@ -53,7 +66,15 @@ services:
     volumes:
       - inway_cert:/inway_cert
       - $GOPATH/src/github.com/VNG-Realisatie/nlx:/go/src/github.com/VNG-Realisatie/nlx
-    command: modd
+    ports:
+      - '2018:2018'
+    command: >
+      /bin/ash -c "
+        while [ ! -f /inway_cert/.done ]; do
+          sleep .2
+        done
+        modd
+      "
 
   outway_cert:
     build:
@@ -63,7 +84,12 @@ services:
       - ca
     volumes:
       - outway_cert:/outway_cert
-    command: /bin/ash -c "cd /outway_cert && /ca/generate-cert.sh outway.nlx.local ca"
+    command: >
+      /bin/ash -c "
+        cd /outway_cert &&
+        /ca/generate-cert.sh outway.nlx.local DemoRequesterOrganization ca &&
+        touch /outway_cert/.done
+      "
 
   outway:
     build:
@@ -76,7 +102,19 @@ services:
       default:
         aliases:
           - outway.nlx.local
+    environment:
+      - TLS_NLX_ROOT_CERT=/outway_cert/nlx_root.pem
+      - TLS_ORG_CERT=/outway_cert/outway_nlx_local.pem
+      - TLS_ORG_KEY=/outway_cert/outway_nlx_local-key.pem
     volumes:
       - outway_cert:/outway_cert
       - $GOPATH/src/github.com/VNG-Realisatie/nlx:/go/src/github.com/VNG-Realisatie/nlx
-    command: modd
+    ports:
+      - '12018:12018'
+    command: >
+      /bin/ash -c "
+        while [ ! -f /outway_cert/.done ]; do
+          sleep .2
+        done
+        modd
+      "

--- a/inway/inway.go
+++ b/inway/inway.go
@@ -4,6 +4,7 @@
 package inway
 
 import (
+	"crypto/x509"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -21,14 +22,18 @@ type Inway struct {
 }
 
 // NewInway creates and prepares a new Inway.
-func NewInway(l *zap.Logger, organizationName string) *Inway {
+func NewInway(l *zap.Logger, roots *x509.CertPool, orgCert *x509.Certificate) (*Inway, error) {
+	if len(orgCert.Subject.Organization) != 1 {
+		return nil, errors.New("cannot obtain organization name from self cert")
+	}
+	organizationName := orgCert.Subject.Organization[0]
 	i := &Inway{
 		logger:           l.With(zap.String("inway-organization-name", organizationName)),
 		organizationName: organizationName,
 
 		serviceEndpoints: make(map[string]ServiceEndpoint),
 	}
-	return i
+	return i, nil
 }
 
 // AddServiceEndpoint adds an ServiceEndpoint to the inway's internal registry.

--- a/inway/modd.conf
+++ b/inway/modd.conf
@@ -1,4 +1,4 @@
 *.go **/*.go {
 	prep: make build
-	daemon +sigkill: ./dist/bin/nlx-inway
+	daemon +sigterm: exec dist/bin/nlx-inway
 }

--- a/outway/modd.conf
+++ b/outway/modd.conf
@@ -1,4 +1,4 @@
 *.go **/*.go {
 	prep: make build
-	daemon +sigkill: ./dist/bin/nlx-outway
+	daemon +sigterm: exec dist/bin/nlx-outway
 }

--- a/outway/outway.go
+++ b/outway/outway.go
@@ -4,6 +4,7 @@
 package outway
 
 import (
+	"crypto/x509"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -21,14 +22,18 @@ type Outway struct {
 }
 
 // NewOutway creates a new Outway and sets it up to handle requests.
-func NewOutway(l *zap.Logger, organizationName string) *Outway {
+func NewOutway(l *zap.Logger, roots *x509.CertPool, orgCert *x509.Certificate) (*Outway, error) {
+	if len(orgCert.Subject.Organization) != 1 {
+		return nil, errors.New("cannot obtain organization name from self cert")
+	}
+	organizationName := orgCert.Subject.Organization[0]
 	i := &Outway{
 		logger:           l.With(zap.String("outway-organization-name", organizationName)),
 		organizationName: organizationName,
 
 		services: make(map[string]*Service),
 	}
-	return i
+	return i, nil
 }
 
 // AddService adds a service and its inway to the outway's internal registry.

--- a/unsafe-ca/generate-cert.sh
+++ b/unsafe-ca/generate-cert.sh
@@ -10,10 +10,12 @@ set -e # exit on error
 certDomain=$1
 certName=`echo ${certDomain} | tr "." "_"`
 
-csrFilename="${certName}-csr.json"
-echo '{"hosts": ["'${certDomain}'"], "key": {"algo": "rsa", "size": 4096}, "names": [{"C": "NL", "ST": "Noord-Holland", "L": "Amsterdam", "O": "Common Ground", "OU": "NLX"}]}' > "${csrFilename}"
+certOrganization=$2
 
-remoteCA=$2
+csrFilename="${certName}-csr.json"
+echo '{"hosts": ["'${certDomain}'"], "key": {"algo": "rsa", "size": 4096}, "CN": "'${certDomain}'", "names": [{"O": "'${certOrganization}'", "OU": "NLX"}]}' > "${csrFilename}"
+
+remoteCA=$3
 ## Wait for remote CA (cfssl server) to be online
 while ! nc -z "${remoteCA}" 8888 </dev/null; do echo "waiting for ca" && sleep 1; done
 ## Fetch root cert from remote CA (cfssl server)

--- a/unsafe-ca/start-ca.sh
+++ b/unsafe-ca/start-ca.sh
@@ -11,7 +11,7 @@ if [ -z "${cadomain}" ]; then
 	exit 1;
 fi;
 
-echo '{"hosts": ["'${cadomain}'"], "key": {"algo": "rsa", "size": 4096}, "names": [{"C": "NL", "ST": "Noord-Holland", "L": "Amsterdam", "O": "Common Ground", "OU": "NLX"}]}' | 
+echo '{"hosts": ["'${cadomain}'"], "key": {"algo": "rsa", "size": 4096}, "names": [{"O": "Common Ground NLX CA", "OU": "NLX"}]}' | 
 	cfssl genkey -initca /dev/stdin | 
 	cfssljson -bare ca
 


### PR DESCRIPTION
- Changed inway to use generated cert to provide HTTPS endpoint.
- Changed outway to only allow inway endpoints with a cert signed by our CA.
- Changed outway to use generated cert for client authentication to inway.
- Changed inway to only allow clients that authenticate with a cert signed by our CA.
- Added authenticated client's subject and issues to inway logs.
- Added common/process package which currently sets up basic signal handling for developer friendly logging.
- Fixed modd.conf for ash (in alpine containers).

The docker-compose file contains some light shell scripting to let inway and outway containers wait for their organizational certs to be ready. This way the components stay unaware of eachother.

This closes #34 and closes #35.

Also unintentionally closes #62, I required the signal handling to debug the signalling problem with modd and ash.