### PR TITLE
Added WORKDIR, EXPOSE and CMD to Dockerfile

### DIFF
--- a/inway/Dockerfile
+++ b/inway/Dockerfile
@@ -16,3 +16,6 @@ RUN make
 # Release binary on latest alpine image.
 FROM alpine:latest
 COPY --from=build /go/src/github.com/VNG-Realisatie/nlx/inway/dist/bin/nlx-inway /usr/local/bin/nlx-inway
+
+EXPOSE 2018
+CMD ["/usr/local/bin/nlx-inway"]

--- a/outway/Dockerfile
+++ b/outway/Dockerfile
@@ -16,3 +16,6 @@ RUN make
 # Release binary on latest alpine image.
 FROM alpine:latest
 COPY --from=build /go/src/github.com/VNG-Realisatie/nlx/outway/dist/bin/nlx-outway /usr/local/bin/nlx-outway
+
+EXPOSE 12018
+CMD ["/usr/local/bin/nlx-outway"]

--- a/unsafe-ca/Dockerfile
+++ b/unsafe-ca/Dockerfile
@@ -10,3 +10,7 @@ FROM alpine:latest
 COPY --from=build-cfssl /go/bin/* /usr/local/bin/
 # Add script to start ca server.
 COPY unsafe-ca/*.sh /ca/
+
+WORKDIR /ca
+EXPOSE 8888
+CMD ["./start-ca.sh", "nlx.local"]


### PR DESCRIPTION
This PR adds some defaults to the Dockerfile, so NLX containers are more easy to deploy.