### PR TITLE
Add initial setup for directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /*/dist
-/**/
 /**/*.swagger.go
 /**/*.swagger.json
 /**/*.pb.go

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 /*/dist
+/**/
+/**/*.swagger.go
+/**/*.swagger.json
+/**/*.pb.go
+/**/*.pb.gw.go
+
 .DS_Store

--- a/common/orgtls/load.go
+++ b/common/orgtls/load.go
@@ -10,14 +10,9 @@ import (
 
 // Load loads the root certs and own cert/key
 func Load(options TLSOptions) (*x509.CertPool, *x509.Certificate, error) {
-	roots := x509.NewCertPool()
-	rootPEM, err := ioutil.ReadFile(options.NLXRootCert)
+	roots, err := LoadRootCert(options.NLXRootCert)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "failed to read NLX CA root PEM file `%s`", options.NLXRootCert)
-	}
-	ok := roots.AppendCertsFromPEM(rootPEM)
-	if !ok {
-		return nil, nil, errors.Errorf("failed to parse NLX CA root PEM from file `%s`", options.NLXRootCert)
+		return nil, nil, err
 	}
 
 	certPEM, err := ioutil.ReadFile(options.OrgCertFile)
@@ -42,4 +37,18 @@ func Load(options TLSOptions) (*x509.CertPool, *x509.Certificate, error) {
 	}
 
 	return roots, cert, nil
+}
+
+// LoadRootCert loads the certificate from file and adds it to a new x509.CertPool which is returned.
+func LoadRootCert(rootCertFile string) (*x509.CertPool, error) {
+	roots := x509.NewCertPool()
+	rootPEM, err := ioutil.ReadFile(rootCertFile)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read NLX CA root PEM file `%s`", rootCertFile)
+	}
+	ok := roots.AppendCertsFromPEM(rootPEM)
+	if !ok {
+		return nil, errors.Errorf("failed to parse NLX CA root PEM from file `%s`", rootCertFile)
+	}
+	return roots, nil
 }

--- a/common/orgtls/options.go
+++ b/common/orgtls/options.go
@@ -2,7 +2,7 @@ package orgtls
 
 // TLSOptions defines the TLS options for a common NLX component.
 type TLSOptions struct {
-	NLXRootCert string `long:"tls-nlx-root-cert" env:"TLS_NLX_ROOT_CERT" description:"Absolute or relative path to the NLX CA root cert .pem"`
-	OrgCertFile string `long:"tls-org-cert" env:"TLS_ORG_CERT" description:"Absolute or relative path to the Organization cert .pem"`
-	OrgKeyFile  string `long:"tls-org-key" env:"TLS_ORG_KEY" description:"Absolute or relative path to the Organization key .pem"`
+	NLXRootCert string `long:"tls-nlx-root-cert" env:"TLS_NLX_ROOT_CERT" description:"Absolute or relative path to the NLX CA root cert .pem" required:"true"`
+	OrgCertFile string `long:"tls-org-cert" env:"TLS_ORG_CERT" description:"Absolute or relative path to the Organization cert .pem" required:"true"`
+	OrgKeyFile  string `long:"tls-org-key" env:"TLS_ORG_KEY" description:"Absolute or relative path to the Organization key .pem" required:"true"`
 }

--- a/directory/.gitignore
+++ b/directory/.gitignore
@@ -1,0 +1,1 @@
+directory-store.json

--- a/directory/Dockerfile
+++ b/directory/Dockerfile
@@ -1,0 +1,18 @@
+# Use go 1.x based on the latest alpine image.
+FROM golang:1-alpine AS build
+
+# Install build tools.
+RUN apk add --update make git
+
+# Install modd, which is used within docker-compose.
+RUN go get github.com/cortesi/modd/cmd/modd
+
+# Add code and build.
+COPY . /go/src/github.com/VNG-Realisatie/nlx
+WORKDIR /go/src/github.com/VNG-Realisatie/nlx/directory
+RUN make
+
+
+# Release binary on latest alpine image.
+FROM alpine:latest
+COPY --from=build /go/src/github.com/VNG-Realisatie/nlx/directory/dist/bin/nlx-directory /usr/local/bin/nlx-directory

--- a/directory/Dockerfile
+++ b/directory/Dockerfile
@@ -2,15 +2,23 @@
 FROM golang:1-alpine AS build
 
 # Install build tools.
-RUN apk add --update make git
+RUN apk add --update make git protobuf
 
-# Install modd, which is used within docker-compose.
-RUN go get github.com/cortesi/modd/cmd/modd
+# Install go-based dependencies and tools
+RUN go get \
+        github.com/cortesi/modd/cmd/modd \
+        google.golang.org/grpc \
+        github.com/golang/protobuf/protoc-gen-go \
+        github.com/gogo/protobuf/protoc-gen-gogofast \
+        github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway \
+        github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger
 
-# Add code and build.
+# Add code.
 COPY . /go/src/github.com/VNG-Realisatie/nlx
 WORKDIR /go/src/github.com/VNG-Realisatie/nlx/directory
-RUN make
+
+# Ignore failing make to allow this stage to complete even when there are errors in the sourcecode.
+RUN make || true 
 
 
 # Release binary on latest alpine image.

--- a/directory/Makefile
+++ b/directory/Makefile
@@ -1,6 +1,10 @@
 
 .PHONY: all
-all: vendor build
+all: clean vendor build
+
+.PHONY: clean
+clean:
+	rm -rf dist
 
 .PHONY: vendor
 vendor:

--- a/directory/Makefile
+++ b/directory/Makefile
@@ -1,0 +1,11 @@
+
+.PHONY: all
+all: vendor build
+
+.PHONY: vendor
+vendor:
+	go get ./...
+
+.PHONY: build
+build:
+	go build -o dist/bin/nlx-directory ./cmd/nlx-directory

--- a/directory/cmd/nlx-directory/main.go
+++ b/directory/cmd/nlx-directory/main.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"crypto/tls"
+	"fmt"
+	"log"
+	"os"
+
+	flags "github.com/svent/go-flags"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/VNG-Realisatie/nlx/common/orgtls"
+	"github.com/VNG-Realisatie/nlx/common/process"
+	"github.com/VNG-Realisatie/nlx/directory/directoryservice"
+)
+
+var options struct {
+	ListenAddress string `long:"listen-address" env:"LISTEN_ADDRESS" default:"0.0.0.0:1984" description:"Adress for the inway to listen on. Read https://golang.org/pkg/net/#Dial for possible tcp address specs."`
+
+	NLXRootCert       string `long:"tls-nlx-root-cert" env:"TLS_NLX_ROOT_CERT" description:"Absolute or relative path to the NLX CA root cert .pem"`
+	DirectoryCertFile string `long:"tls-directory-cert" env:"TLS_DIRECTORY_CERT" description:"Absolute or relative path to the Directory cert .pem"`
+	DirectoryKeyFile  string `long:"tls-directory-key" env:"TLS_DIRECTORY_KEY" description:"Absolute or relative path to the Directory key .pem"`
+}
+
+func main() {
+	// Parse options
+	args, err := flags.Parse(&options)
+	if err != nil {
+		if et, ok := err.(*flags.Error); ok {
+			if et.Type == flags.ErrHelp {
+				return
+			}
+		}
+		log.Fatalf("error parsing flags: %v", err)
+	}
+	if len(args) > 0 {
+		log.Fatalf("unexpected arguments: %v", args)
+	}
+
+	// Setup new zap logger
+	config := zap.NewDevelopmentConfig()
+	config.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
+	logger, err := config.Build()
+	if err != nil {
+		log.Fatalf("failed to create new zap logger: %v", err)
+	}
+	defer func() { // TODO(GeertJohan): make this a common/process exitFunc?
+		syncErr := logger.Sync()
+		if syncErr != nil {
+			// notify the user that proper logging has failed
+			fmt.Fprintf(os.Stderr, "failed to sync zap logger: %v\n", syncErr)
+			// don't exit when we're in a panic
+			if p := recover(); p != nil {
+				panic(p)
+			}
+			os.Exit(1)
+		}
+	}()
+
+	process.Setup(logger)
+
+	directoryService, err := directoryservice.New(logger)
+	if err != nil {
+		logger.Fatal("failed to create new directory service", zap.Error(err))
+	}
+
+	caCertPool, err := orgtls.LoadRootCert(options.NLXRootCert)
+	if err != nil {
+		logger.Fatal("failed to load root cert", zap.Error(err))
+	}
+	certKeyPair, err := tls.LoadX509KeyPair(options.DirectoryCertFile, options.DirectoryKeyFile)
+	if err != nil {
+		logger.Fatal("failed to load x509 keypair for directory", zap.Error(err))
+	}
+	runServer(logger, options.ListenAddress, caCertPool, certKeyPair, directoryService)
+}

--- a/directory/cmd/nlx-directory/server.go
+++ b/directory/cmd/nlx-directory/server.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"runtime/debug"
+	"strings"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
+	"github.com/grpc-ecosystem/go-grpc-middleware/recovery"
+	"github.com/grpc-ecosystem/go-grpc-middleware/tags"
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"go.uber.org/zap"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+
+	"github.com/VNG-Realisatie/nlx/directory/directoryapi"
+)
+
+// newGRPCSplitterHandlerFunc returns an http.Handler that delegates gRPC connections to grpcServer
+// and all other connections to otherHandler.
+func newGRPCSplitterHandlerFunc(grpcServer *grpc.Server, otherHandler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// gRPC connection detected when HTTP protocol is version 2 and content-type is application/grpc
+		if r.ProtoMajor == 2 && strings.Contains(r.Header.Get("Content-Type"), "application/grpc") {
+			grpcServer.ServeHTTP(w, r)
+		} else {
+			otherHandler.ServeHTTP(w, r)
+		}
+	})
+}
+
+// runServer is a blocking function which sets up the grpc and http/json server and runs them on a single address/port.
+func runServer(log *zap.Logger, address string, caCertPool *x509.CertPool, certKeyPair tls.Certificate, directoryService directoryapi.DirectoryServer) {
+
+	// setup logrus connection for global grpc logging
+	grpc_zap.ReplaceGrpcLogger(log)
+
+	recoveryOptions := []grpc_recovery.Option{
+		grpc_recovery.WithRecoveryHandler(func(p interface{}) error {
+			log.Warn("recovered from a panic in a grpc request handler", zap.ByteString("stack", debug.Stack()))
+			return grpc.Errorf(codes.Internal, "%s", p)
+		}),
+	}
+
+	// prepare grpc server options
+	opts := []grpc.ServerOption{
+		grpc.Creds(credentials.NewClientTLSFromCert(caCertPool, "")),
+		grpc_middleware.WithStreamServerChain(
+			grpc_ctxtags.StreamServerInterceptor(),
+			grpc_zap.StreamServerInterceptor(log),
+			grpc_recovery.StreamServerInterceptor(recoveryOptions...),
+		),
+		grpc_middleware.WithUnaryServerChain(
+			grpc_ctxtags.UnaryServerInterceptor(),
+			grpc_zap.UnaryServerInterceptor(log),
+			grpc_recovery.UnaryServerInterceptor(recoveryOptions...),
+		),
+	}
+
+	// start grpc server and attach director service
+	grpcServer := grpc.NewServer(opts...)
+	directoryapi.RegisterDirectoryServer(grpcServer, directoryService)
+
+	// setup client credentials for grpc gateway
+	gatewayDialOptions := []grpc.DialOption{
+		grpc.WithTransportCredentials(
+			credentials.NewTLS(&tls.Config{
+				ServerName:         address,
+				RootCAs:            caCertPool,
+				InsecureSkipVerify: true, // TODO: remove when setting up deployment to live environment
+			}),
+		),
+	}
+
+	// root http serve mux
+	httpRouter := http.NewServeMux()
+	httpRouter.HandleFunc("/swagger.json", func(w http.ResponseWriter, req *http.Request) {
+		io.Copy(w, strings.NewReader(directoryapi.SwaggerJSONDirectory))
+	})
+
+	// setup grpc gateway and attach to main mux
+	gatewayMux := runtime.NewServeMux()
+	err := directoryapi.RegisterDirectoryHandlerFromEndpoint(context.Background(), gatewayMux, address, gatewayDialOptions)
+	if err != nil {
+		fmt.Printf("serve: %v\n", err)
+		return
+	}
+	httpRouter.Handle("/", gatewayMux)
+
+	// setup connection and http server
+	conn, err := net.Listen("tcp", address)
+	if err != nil {
+		log.With(zap.Error(err)).Fatal(fmt.Sprintf("could not listen on %s", address))
+	}
+
+	srv := &http.Server{
+		Addr:    address,
+		Handler: newGRPCSplitterHandlerFunc(grpcServer, httpRouter),
+		TLSConfig: &tls.Config{
+			Certificates: []tls.Certificate{certKeyPair},
+			NextProtos:   []string{"h2"},
+		},
+	}
+
+	err = srv.Serve(tls.NewListener(conn, srv.TLSConfig))
+	if err != nil {
+		log.With(zap.Error(err)).Fatal("ListenAndServe failed")
+	}
+
+	return
+}

--- a/directory/directory-store.json
+++ b/directory/directory-store.json
@@ -1,1 +1,0 @@
-{"Services":{"PostmanEcho":{"OrganizationName":"DemoProviderOrganization","ServiceName":"PostmanEcho","InwayAddresses":{"inway.nlx.local:2018":true}}}}

--- a/directory/directory-store.json
+++ b/directory/directory-store.json
@@ -1,1 +1,1 @@
-{"Services":{"PostmanEcho":{"OrganizationName":"","ServiceName":"PostmanEcho","InwayAddresses":{"inway.nlx.local:2018":true}}}}
+{"Services":{"PostmanEcho":{"OrganizationName":"DemoProviderOrganization","ServiceName":"PostmanEcho","InwayAddresses":{"inway.nlx.local:2018":true}}}}

--- a/directory/directory-store.json
+++ b/directory/directory-store.json
@@ -1,0 +1,1 @@
+{"Services":{"PostmanEcho":{"OrganizationName":"","ServiceName":"PostmanEcho","InwayAddresses":{"inway.nlx.local:2018":true}}}}

--- a/directory/directoryapi/Makefile
+++ b/directory/directoryapi/Makefile
@@ -1,0 +1,37 @@
+
+all: generate
+generate: clean
+
+	@# Generate go, gateway, validators
+	protoc -I. \
+		-I$(GOPATH)/src \
+		-I$(GOPATH)/src/github.com/gogo/protobuf/protobuf \
+		-I$(GOPATH)/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis \
+		--gogofast_out=\
+Mgoogle/protobuf/any.proto=github.com/gogo/protobuf/types,\
+Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types,\
+Mgoogle/protobuf/struct.proto=github.com/gogo/protobuf/types,\
+Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,\
+Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types,\
+plugins=grpc:. \
+		--grpc-gateway_out=logtostderr=true:. \
+		*.proto
+	
+	@# Generate swagger.json
+	protoc -I. \
+		-I$(GOPATH)/src \
+		-I$(GOPATH)/src/github.com/gogo/protobuf/protobuf \
+		-I$(GOPATH)/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis \
+		--swagger_out=logtostderr=true:. \
+		directory.proto
+	echo 'package directoryapi'      > directory.swagger.go
+	echo 'const ('                  >> directory.swagger.go
+	echo 'SwaggerJSONDirectory = `' >> directory.swagger.go
+	cat directory.swagger.json      >> directory.swagger.go
+	echo '`)'                       >> directory.swagger.go
+
+
+clean:
+	@# Remove old generated files
+	rm -f *.pb.go
+	rm -f *.pb.gw.go

--- a/directory/directoryapi/Makefile
+++ b/directory/directoryapi/Makefile
@@ -1,5 +1,7 @@
-
+.PHONY: all
 all: generate
+
+.PHONY: generate
 generate: clean
 
 	@# Generate go, gateway, validators
@@ -30,8 +32,10 @@ plugins=grpc:. \
 	cat directory.swagger.json      >> directory.swagger.go
 	echo '`)'                       >> directory.swagger.go
 
-
+.PHONY: clean
 clean:
 	@# Remove old generated files
 	rm -f *.pb.go
 	rm -f *.pb.gw.go
+	rm -f *.swagger.json
+	rm -f *.swagger.go

--- a/directory/directoryapi/directory.proto
+++ b/directory/directoryapi/directory.proto
@@ -15,9 +15,9 @@ option (gogoproto.goproto_getters_all) = false;
 service Directory {
 	// RegisterInway registers an inway for a given service
 	rpc RegisterInway (RegisterInwayRequest) returns (RegisterInwayResponse) {}
-	// GetServices lists all services and their gateways.
-	rpc GetServices (GetServicesRequest) returns (GetServicesResponse) {
-		option (google.api.http).get = "/directory/services";
+	// ListServices lists all services and their gateways.
+	rpc ListServices (ListServicesRequest) returns (ListServicesResponse) {
+		option (google.api.http).get = "/directory/list-services";
 	}
 }
 
@@ -30,9 +30,9 @@ message RegisterInwayResponse {
 	string error = 1;
 }
 
-message GetServicesRequest {}
+message ListServicesRequest {}
 
-message GetServicesResponse {
+message ListServicesResponse {
 	string error = 1;
 	repeated Service services = 2;
 }

--- a/directory/directoryapi/directory.proto
+++ b/directory/directoryapi/directory.proto
@@ -1,0 +1,50 @@
+syntax = "proto3";
+
+// Package directoryapi defines the directory api.
+package directoryapi;
+
+import "google/api/annotations.proto";
+import "github.com/gogo/protobuf/gogoproto/gogo.proto";
+
+option (gogoproto.marshaler_all) = true;
+option (gogoproto.sizer_all) = true;
+option (gogoproto.unmarshaler_all) = true;
+option (gogoproto.goproto_getters_all) = false;
+
+// The Directory service definition.
+service Directory {
+	// RegisterInway registers an inway for a given service
+	rpc RegisterInway (RegisterInwayRequest) returns (RegisterInwayResponse) {
+		option (google.api.http) = {
+			post: "/directory/register-inway"
+			body: "*"
+		};
+	}
+	// GetServices lists all services and their gateways.
+	rpc GetServices (GetServicesRequest) returns (GetServicesResponse) {
+		option (google.api.http).get = "/directory/services";
+	}
+}
+
+message RegisterInwayRequest {
+	string organization_name = 1;
+	string inway_address = 2;
+	repeated string service_names = 3;
+}
+
+message RegisterInwayResponse {
+	string error = 1;
+}
+
+message GetServicesRequest {}
+
+message GetServicesResponse {
+	string error = 1;
+	repeated Service services = 2;
+}
+
+message Service {
+	string name = 1;
+	string organization_name = 2;
+	repeated string inwayAddresses = 3;
+}

--- a/directory/directoryapi/directory.proto
+++ b/directory/directoryapi/directory.proto
@@ -14,12 +14,7 @@ option (gogoproto.goproto_getters_all) = false;
 // The Directory service definition.
 service Directory {
 	// RegisterInway registers an inway for a given service
-	rpc RegisterInway (RegisterInwayRequest) returns (RegisterInwayResponse) {
-		option (google.api.http) = {
-			post: "/directory/register-inway"
-			body: "*"
-		};
-	}
+	rpc RegisterInway (RegisterInwayRequest) returns (RegisterInwayResponse) {}
 	// GetServices lists all services and their gateways.
 	rpc GetServices (GetServicesRequest) returns (GetServicesResponse) {
 		option (google.api.http).get = "/directory/services";
@@ -27,9 +22,8 @@ service Directory {
 }
 
 message RegisterInwayRequest {
-	string organization_name = 1;
-	string inway_address = 2;
-	repeated string service_names = 3;
+	string inway_address = 1;
+	repeated string service_names = 2;
 }
 
 message RegisterInwayResponse {

--- a/directory/directoryservice/directory.go
+++ b/directory/directoryservice/directory.go
@@ -1,0 +1,35 @@
+package directoryservice
+
+import (
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+
+	"github.com/VNG-Realisatie/nlx/directory/directoryapi"
+)
+
+// compile-time interface implementation verification
+var _ directoryapi.DirectoryServer = &DirectoryService{}
+
+// DirectoryService handles all requests for a directory api
+type DirectoryService struct {
+	*registerInwayHandler
+	*getServicesHandler
+}
+
+// New sets up a new DirectoryService and returns an error when something failed during set.
+func New(logger *zap.Logger) (*DirectoryService, error) {
+	s := &DirectoryService{}
+
+	var err error
+
+	s.registerInwayHandler, err = newRegisterInwayHandler(logger)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to setup RegisterInway handler")
+	}
+	s.getServicesHandler, err = newGetServicesHandler(logger)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to setup GetServices handler")
+	}
+
+	return s, nil
+}

--- a/directory/directoryservice/directory.go
+++ b/directory/directoryservice/directory.go
@@ -13,7 +13,7 @@ var _ directoryapi.DirectoryServer = &DirectoryService{}
 // DirectoryService handles all requests for a directory api
 type DirectoryService struct {
 	*registerInwayHandler
-	*getServicesHandler
+	*listServicesHandler
 }
 
 // New sets up a new DirectoryService and returns an error when something failed during set.
@@ -26,9 +26,9 @@ func New(logger *zap.Logger) (*DirectoryService, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to setup RegisterInway handler")
 	}
-	s.getServicesHandler, err = newGetServicesHandler(logger)
+	s.listServicesHandler, err = newListServicesHandler(logger)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to setup GetServices handler")
+		return nil, errors.Wrap(err, "failed to setup ListServices handler")
 	}
 
 	return s, nil

--- a/directory/directoryservice/get-services.go
+++ b/directory/directoryservice/get-services.go
@@ -1,0 +1,37 @@
+package directoryservice
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+
+	"github.com/VNG-Realisatie/nlx/directory/directoryapi"
+)
+
+type getServicesHandler struct{}
+
+func newGetServicesHandler(logger *zap.Logger) (*getServicesHandler, error) {
+	return &getServicesHandler{}, nil
+}
+
+func (p *getServicesHandler) GetServices(ctx context.Context, req *directoryapi.GetServicesRequest) (*directoryapi.GetServicesResponse, error) {
+	fmt.Println("rpc request GetServices()")
+	repl := &directoryapi.GetServicesResponse{}
+
+	store.ServicesLock.RLock()
+	defer store.ServicesLock.RUnlock()
+
+	for serviceName, service := range store.Services {
+		s := &directoryapi.Service{
+			Name:             serviceName,
+			OrganizationName: service.OrganizationName,
+		}
+		for inwayAddress := range service.InwayAddresses {
+			s.InwayAddresses = append(s.InwayAddresses, inwayAddress)
+		}
+		repl.Services = append(repl.Services, s)
+	}
+
+	return repl, nil
+}

--- a/directory/directoryservice/list-services.go
+++ b/directory/directoryservice/list-services.go
@@ -9,15 +9,15 @@ import (
 	"github.com/VNG-Realisatie/nlx/directory/directoryapi"
 )
 
-type getServicesHandler struct{}
+type listServicesHandler struct{}
 
-func newGetServicesHandler(logger *zap.Logger) (*getServicesHandler, error) {
-	return &getServicesHandler{}, nil
+func newListServicesHandler(logger *zap.Logger) (*listServicesHandler, error) {
+	return &listServicesHandler{}, nil
 }
 
-func (p *getServicesHandler) GetServices(ctx context.Context, req *directoryapi.GetServicesRequest) (*directoryapi.GetServicesResponse, error) {
-	fmt.Println("rpc request GetServices()")
-	repl := &directoryapi.GetServicesResponse{}
+func (p *listServicesHandler) ListServices(ctx context.Context, req *directoryapi.ListServicesRequest) (*directoryapi.ListServicesResponse, error) {
+	fmt.Println("rpc request ListServices()")
+	repl := &directoryapi.ListServicesResponse{}
 
 	store.ServicesLock.RLock()
 	defer store.ServicesLock.RUnlock()

--- a/directory/directoryservice/register-inway.go
+++ b/directory/directoryservice/register-inway.go
@@ -1,0 +1,34 @@
+package directoryservice
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/VNG-Realisatie/nlx/directory/directoryapi"
+	"go.uber.org/zap"
+)
+
+type registerInwayHandler struct{}
+
+func newRegisterInwayHandler(logger *zap.Logger) (*registerInwayHandler, error) {
+	return &registerInwayHandler{}, nil
+}
+
+func (p *registerInwayHandler) RegisterInway(ctx context.Context, req *directoryapi.RegisterInwayRequest) (*directoryapi.RegisterInwayResponse, error) {
+	fmt.Printf("rpc request RegisterInway(%s, %s)\n", req.OrganizationName, req.InwayAddress)
+	repl := &directoryapi.RegisterInwayResponse{}
+
+	store.ServicesLock.Lock()
+	defer store.SaveAndUnlock()
+
+	for _, serviceName := range req.ServiceNames {
+		service, exists := store.Services[serviceName]
+		if !exists {
+			service = NewStoredService(req.OrganizationName, serviceName)
+			store.Services[serviceName] = service
+		}
+		service.InwayAddresses[req.InwayAddress] = true
+	}
+
+	return repl, nil
+}

--- a/directory/directoryservice/register-inway.go
+++ b/directory/directoryservice/register-inway.go
@@ -18,7 +18,7 @@ func newRegisterInwayHandler(logger *zap.Logger) (*registerInwayHandler, error) 
 }
 
 func (p *registerInwayHandler) RegisterInway(ctx context.Context, req *directoryapi.RegisterInwayRequest) (*directoryapi.RegisterInwayResponse, error) {
-	fmt.Printf("rpc request RegisterInway(%s, %s)\n", req.OrganizationName, req.InwayAddress)
+	fmt.Printf("rpc request RegisterInway(%s)\n", req.InwayAddress)
 	repl := &directoryapi.RegisterInwayResponse{}
 
 	peer, ok := peer.FromContext(ctx)

--- a/directory/directoryservice/register-inway.go
+++ b/directory/directoryservice/register-inway.go
@@ -2,10 +2,13 @@ package directoryservice
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/VNG-Realisatie/nlx/directory/directoryapi"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
 )
 
 type registerInwayHandler struct{}
@@ -18,13 +21,22 @@ func (p *registerInwayHandler) RegisterInway(ctx context.Context, req *directory
 	fmt.Printf("rpc request RegisterInway(%s, %s)\n", req.OrganizationName, req.InwayAddress)
 	repl := &directoryapi.RegisterInwayResponse{}
 
+	peer, ok := peer.FromContext(ctx)
+	if !ok {
+		return nil, errors.New("failed to obtain peer from context")
+	}
+	tlsInfo := peer.AuthInfo.(credentials.TLSInfo)
+	organizationName := tlsInfo.State.VerifiedChains[0][0].Subject.Organization[0]
+	// TODO: when administrative (client-tls mandatory) and inspection (client-tls optional) endpoints have been seperated,
+	// use proper grpc authentication via middleware and context (based on client-tls fields (CN, O) like we do here)
+
 	store.ServicesLock.Lock()
 	defer store.SaveAndUnlock()
 
 	for _, serviceName := range req.ServiceNames {
 		service, exists := store.Services[serviceName]
 		if !exists {
-			service = NewStoredService(req.OrganizationName, serviceName)
+			service = NewStoredService(organizationName, serviceName)
 			store.Services[serviceName] = service
 		}
 		service.InwayAddresses[req.InwayAddress] = true

--- a/directory/directoryservice/store.go
+++ b/directory/directoryservice/store.go
@@ -1,0 +1,92 @@
+package directoryservice
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+	"sync"
+)
+
+var (
+	store = NewStore("./directory-store.json")
+)
+
+// In the absence of a database, just store services in-memory and save to JSON file.
+// This file is poorly documented as it is just a temporary store for PoC.
+
+type StoredService struct {
+	OrganizationName string
+	ServiceName      string
+	InwayAddresses   map[string]bool
+}
+
+func NewStoredService(orgName, serviceName string) *StoredService {
+	return &StoredService{
+		OrganizationName: orgName,
+		ServiceName:      serviceName,
+		InwayAddresses:   make(map[string]bool),
+	}
+}
+
+type Store struct {
+	savePath string // path/to/file.json
+
+	ServicesLock sync.RWMutex `json:"-"` // lock protects the services map
+	Services     map[string]*StoredService
+}
+
+func NewStore(savePath string) *Store {
+	saveFile, err := os.Open(savePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			s := &Store{
+				savePath: savePath,
+				Services: make(map[string]*StoredService),
+			}
+			s.Save()
+			return s
+		}
+		log.Fatalf("failed to open exising save file: %v", err)
+	}
+	s := &Store{
+		savePath: savePath,
+	}
+	err = json.NewDecoder(saveFile).Decode(s)
+	if err != nil {
+		log.Fatalf("failed to decode store save contents: %v", err)
+	}
+	return s
+}
+
+// Save can be calld on a store to save it to disk.
+// Note that the Save() call itself acuires a write-lock, so the caller must not keep any lock.
+func (s *Store) Save() {
+	s.ServicesLock.Lock()
+	defer s.ServicesLock.Unlock()
+	s.save()
+}
+
+// SaveAndUnlock can be called on a write-locked store and saves then unlocks the store.
+func (s *Store) SaveAndUnlock() {
+	defer s.ServicesLock.Unlock()
+	s.save()
+}
+
+func (s *Store) save() {
+	newsavePath := s.savePath + ".new"
+
+	newsaveFile, err := os.Create(newsavePath)
+	if err != nil {
+		log.Fatalf("failed to create new store save file: %v", err)
+	}
+
+	err = json.NewEncoder(newsaveFile).Encode(s)
+	if err != nil {
+		log.Fatalf("failed to encode json to file: %v", err)
+	}
+
+	err = os.Rename(newsavePath, s.savePath)
+	if err != nil {
+		log.Fatalf("error saving store: %v", err)
+	}
+}

--- a/directory/modd.conf
+++ b/directory/modd.conf
@@ -1,5 +1,5 @@
 *.go **/*.go Makefile {
 	prep: make vendor
 	prep: make build
-	daemon +sigterm: exec dist/bin/nlx-inway
+	daemon +sigterm: exec dist/bin/nlx-directory
 }

--- a/directory/modd.conf
+++ b/directory/modd.conf
@@ -3,3 +3,7 @@
 	prep: make build
 	daemon +sigterm: exec dist/bin/nlx-directory
 }
+
+directoryapi/*.proto {
+	prep: make -C directoryapi
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,6 +113,7 @@ services:
       - TLS_NLX_ROOT_CERT=/outway_cert/nlx_root.pem
       - TLS_ORG_CERT=/outway_cert/outway_nlx_local.pem
       - TLS_ORG_KEY=/outway_cert/outway_nlx_local-key.pem
+      - DIRECTORY_ADDRESS=directory.nlx.local:1984
     volumes:
       - outway_cert:/outway_cert
       - $GOPATH/src/github.com/VNG-Realisatie/nlx:/go/src/github.com/VNG-Realisatie/nlx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,11 @@ volumes:
     driver_opts:
       type: tmpfs
       device: tmpfs
+  directory_cert:
+    driver: local
+    driver_opts:
+      type: tmpfs
+      device: tmpfs
 
 services:
   docs:
@@ -63,6 +68,8 @@ services:
       - TLS_NLX_ROOT_CERT=/inway_cert/nlx_root.pem
       - TLS_ORG_CERT=/inway_cert/inway_nlx_local.pem
       - TLS_ORG_KEY=/inway_cert/inway_nlx_local-key.pem
+      - SELF_ADDRESS=inway.nlx.local:2018
+      - DIRECTORY_ADDRESS=directory.nlx.local:1984
     volumes:
       - inway_cert:/inway_cert
       - $GOPATH/src/github.com/VNG-Realisatie/nlx:/go/src/github.com/VNG-Realisatie/nlx
@@ -118,7 +125,6 @@ services:
         done
         modd
       "
-    command: modd
 
   certportal:
     build:
@@ -134,3 +140,46 @@ services:
     ports:
       - '12020:12020'
     command: modd
+
+  directory_cert:
+    build:
+      context: .
+      dockerfile: unsafe-ca/Dockerfile
+    depends_on:
+      - ca
+    volumes:
+      - directory_cert:/directory_cert
+    command: >
+      /bin/ash -c "
+        cd /directory_cert &&
+        /ca/generate-cert.sh directory.nlx.local NLX ca &&
+        touch /directory_cert/.done
+      "
+
+  directory:
+    build:
+      context: .
+      dockerfile: directory/Dockerfile
+      target: build
+    depends_on:
+      - directory_cert
+    networks:
+      default:
+        aliases:
+          - directory.nlx.local
+    environment:
+      - TLS_NLX_ROOT_CERT=/directory_cert/nlx_root.pem
+      - TLS_DIRECTORY_CERT=/directory_cert/directory_nlx_local.pem
+      - TLS_DIRECTORY_KEY=/directory_cert/directory_nlx_local-key.pem
+    volumes:
+      - directory_cert:/directory_cert
+      - $GOPATH/src/github.com/VNG-Realisatie/nlx:/go/src/github.com/VNG-Realisatie/nlx
+    ports:
+      - '1984:1984'
+    command: >
+      /bin/ash -c "
+        while [ ! -f /directory_cert/.done ]; do
+          sleep .2
+        done
+        modd
+      "

--- a/inway/Dockerfile
+++ b/inway/Dockerfile
@@ -7,10 +7,12 @@ RUN apk add --update make git
 # Install modd, which is used within docker-compose.
 RUN go get github.com/cortesi/modd/cmd/modd
 
-# Add code and build.
+# Add code.
 COPY . /go/src/github.com/VNG-Realisatie/nlx
 WORKDIR /go/src/github.com/VNG-Realisatie/nlx/inway
-RUN make
+
+# Ignore failing make to allow this stage to complete even when there are errors in the sourcecode.
+RUN make || true 
 
 
 # Release binary on latest alpine image.

--- a/inway/Makefile
+++ b/inway/Makefile
@@ -1,6 +1,10 @@
 
 .PHONY: all
-all: vendor build
+all: clean vendor build
+
+.PHONY: clean
+clean:
+	rm -rf dist
 
 .PHONY: vendor
 vendor:

--- a/inway/cmd/nlx-inway/main.go
+++ b/inway/cmd/nlx-inway/main.go
@@ -4,21 +4,34 @@
 package main
 
 import (
+	"context"
+	"crypto/tls"
 	"fmt"
 	"log"
 	"os"
+	"time"
+
+	"google.golang.org/grpc/codes"
 
 	flags "github.com/jessevdk/go-flags"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/status"
 
 	"github.com/VNG-Realisatie/nlx/common/orgtls"
 	"github.com/VNG-Realisatie/nlx/common/process"
+	"github.com/VNG-Realisatie/nlx/directory/directoryapi"
 	"github.com/VNG-Realisatie/nlx/inway"
 )
 
 var options struct {
 	ListenAddress string `long:"listen-address" env:"LISTEN_ADDRESS" default:"0.0.0.0:2018" description:"Adress for the inway to listen on. Read https://golang.org/pkg/net/#Dial for possible tcp address specs."`
+
+	DirectoryAddress string `long:"directory-address" env:"DIRECTORY_ADDRESS" description:"Address for the directory where this inway can register it's services" required:"true"`
+
+	SelfAddress string `long:"self-address" env:"SELF_ADDRESS" description:"The address that outways can use to reach me" required:"true"`
 
 	orgtls.TLSOptions
 }
@@ -65,6 +78,40 @@ func main() {
 	if err != nil {
 		fmt.Println(err)
 		logger.Fatal("failed to load tls certs", zap.Error(err))
+	}
+
+	{
+		directoryDialCredentials := credentials.NewTLS(&tls.Config{
+			RootCAs: roots,
+		})
+		directoryDialOptions := []grpc.DialOption{
+			grpc.WithTransportCredentials(directoryDialCredentials),
+		}
+		directoryConnCtx, _ := context.WithTimeout(context.Background(), 1*time.Minute)
+		directoryConn, err := grpc.DialContext(directoryConnCtx, options.DirectoryAddress, directoryDialOptions...)
+		if err != nil {
+			logger.Fatal("failed to setup connection to directory service", zap.Error(err))
+		}
+		directoryClient := directoryapi.NewDirectoryClient(directoryConn)
+		for {
+			resp, err := directoryClient.RegisterInway(context.Background(), &directoryapi.RegisterInwayRequest{
+				InwayAddress: options.SelfAddress,
+				ServiceNames: []string{"PostmanEcho"},
+			})
+			if err != nil {
+
+				if errStatus, ok := status.FromError(err); ok && errStatus.Code() == codes.Unavailable {
+					logger.Info("waiting for director...")
+					time.Sleep(100 * time.Millisecond)
+					continue
+				}
+				logger.Error("failed to register to directory", zap.Error(err))
+			}
+			if resp != nil && resp.Error != "" {
+				logger.Error(fmt.Sprintf("failed to register to directory: %s", resp.Error))
+			}
+			break
+		}
 	}
 
 	// Create new inway and provide it with a hardcoded service.

--- a/inway/cmd/nlx-inway/main.go
+++ b/inway/cmd/nlx-inway/main.go
@@ -80,9 +80,14 @@ func main() {
 		logger.Fatal("failed to load tls certs", zap.Error(err))
 	}
 
-	{
+	{ // TODO: move this into revised Inway structure
+		clientCert, err := tls.LoadX509KeyPair(options.OrgCertFile, options.OrgKeyFile)
+		if err != nil {
+			logger.Fatal("failed to load tls cert file", zap.Error(err))
+		}
 		directoryDialCredentials := credentials.NewTLS(&tls.Config{
-			RootCAs: roots,
+			Certificates: []tls.Certificate{clientCert},
+			RootCAs:      roots,
 		})
 		directoryDialOptions := []grpc.DialOption{
 			grpc.WithTransportCredentials(directoryDialCredentials),

--- a/outway/Dockerfile
+++ b/outway/Dockerfile
@@ -10,7 +10,9 @@ RUN go get github.com/cortesi/modd/cmd/modd
 # Add code and build.
 COPY . /go/src/github.com/VNG-Realisatie/nlx
 WORKDIR /go/src/github.com/VNG-Realisatie/nlx/outway
-RUN make
+
+# Ignore failing make to allow this stage to complete even when there are errors in the sourcecode.
+RUN make || true 
 
 
 # Release binary on latest alpine image.

--- a/outway/Makefile
+++ b/outway/Makefile
@@ -1,6 +1,10 @@
 
 .PHONY: all
-all: vendor build
+all: clean vendor build
+
+.PHONY: clean
+clean:
+	rm -rf dist
 
 .PHONY: vendor
 vendor:

--- a/outway/modd.conf
+++ b/outway/modd.conf
@@ -1,4 +1,5 @@
 *.go **/*.go {
+	prep: make vendor
 	prep: make build
 	daemon +sigterm: exec dist/bin/nlx-outway
 }

--- a/outway/service.go
+++ b/outway/service.go
@@ -29,14 +29,19 @@ type Service struct {
 // NewService creates a new Service instance with a single inway to forward requests to.
 // This is a PoC shortcut, the real outway will fetch services and their inways* from the directory
 // 		(* note the plural; a service can have multiple inways published by directory so that an outway can balance load to multiple inways)
-func NewService(logger *zap.Logger, roots *x509.CertPool, certFile string, keyFile string, organizationName, serviceName string, inwayAddress string) (*Service, error) {
+func NewService(logger *zap.Logger, roots *x509.CertPool, certFile string, keyFile string, organizationName, serviceName string, inwayAddresses []string) (*Service, error) {
+	if len(inwayAddresses) == 0 {
+		return nil, errors.New("expecting at least one inway address")
+	}
+	inwayAddress := inwayAddresses[0] // no loadbalancing etc. yet in poc, just using the first inway available
+
 	s := &Service{
 		organizationName: organizationName,
 		serviceName:      serviceName,
 		roots:            roots,
 	}
 	s.logger = logger.With(zap.String("outway-service-full-name", s.fullName()))
-	endpointURL, err := url.Parse(inwayAddress)
+	endpointURL, err := url.Parse("https://" + inwayAddress)
 	if err != nil {
 		return nil, errors.Wrap(err, "invalid endpoint provided")
 	}


### PR DESCRIPTION
- directory serves a single endpoint for both gRPC and http/json
- on this endpoint there is a registration and retrieval method available. (see directory/directoryapi/directory.proto)
- /swagger.json describing the http/json posibilities
- inway automatically registers to the directory
- docker-compose additions to run the directory locally with CA-signed cert
- directory uses a simple json-file backed store for the services so the store survives restarts during development