### PR TITLE
inway: Add X-NLX-Requester-Organization header to forwarded requests

### DIFF
--- a/inway/listen.go
+++ b/inway/listen.go
@@ -38,9 +38,9 @@ func (i *Inway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		zap.String("request-path", r.URL.Path),
 		zap.String("request-remote-address", r.RemoteAddr),
 	)
-	subject := r.TLS.PeerCertificates[0].Subject.Organization[0]
+	subjectOrganization := r.TLS.PeerCertificates[0].Subject.Organization[0]
 	issuer := r.TLS.PeerCertificates[0].Issuer.Organization[0]
-	logger = logger.With(zap.String("issuer", issuer), zap.String("subject", subject))
+	logger = logger.With(zap.String("issuer", issuer), zap.String("subject", subjectOrganization))
 	logger.Debug("received request")
 
 	// simple health check
@@ -57,6 +57,8 @@ func (i *Inway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	serviceName := urlparts[0]
 	r.URL.Path = urlparts[1]
+
+	r.Header.Set("X-NLX-Requester-Organization", subjectOrganization)
 
 	i.serviceEndpointsLock.RLock()
 	serviceEndpoint := i.serviceEndpoints[serviceName]


### PR DESCRIPTION
The echo service that is set up by default in the docker-compose stack nicely shows the header:

```
$ curl "http://localhost:12018/DemoProviderOrganization/PostmanEcho/get?foo=1"
{"args":{"foo":"1"},"headers":{"host":"localhost","accept":"*/*","accept-encoding":"gzip","user-agent":"curl/7.55.1","x-nlx-requester-organization":"DemoRequesterOrganization","x-forwarded-port":"443","x-forwarded-proto":"https"},"url":"https://localhost/get?foo=1"}
```
excerpt: `"x-nlx-requester-organization":"DemoRequesterOrganization"` (the lowercasing of the header is performed by the echo service)

fixes #87 