### PR TITLE
Change the status badge to 'proof of concept'

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The current goal of this project is to deliver a Proof of Concept for the [NLX P
 Read more on how to ask questions, file bugs and contribute code and documentation in [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 ## Documentation
-Please find the latest documentation of NLX on https://docs.nlx.io/. This is a good place to start if you would like to develop an application or service on top of NLX.
+Please find the latest documentation of NLX on [docs.nlx.io](https://docs.nlx.io). This is a good place to start if you would like to develop an application or service on top of NLX.
 
 ## Build and run NLX locally
 If you would like to deploy an NLX network on your local machine or contribute to the NLX code please follow these steps.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 NLX
 ===
-[![Build Status](https://jenkins.nlx.io/job/nlx-release-master/badge/icon?style=plastic)](https://jenkins.nlx.io/) ![Repo Status](https://img.shields.io/badge/status-concept-lightgrey.svg?style=plastic)
+[![Build Status](https://jenkins.nlx.io/job/nlx-release-master/badge/icon?style=plastic)](https://jenkins.nlx.io/) ![Repo Status](https://img.shields.io/badge/status-proof%20of%20concept-lightgrey.svg?longCache=true&style=plastic)
 
 **NLX** is an open source inter-organisational system facilitating federated authentication, secure connecting and protocolling in a large-scale, dynamic API landscape.
 


### PR DESCRIPTION
To reflect that what is published now is working software, whilst
not meant for production or to be a pre-release of real software.